### PR TITLE
Valid cloudformation check

### DIFF
--- a/infra/buildspecs/test.yaml
+++ b/infra/buildspecs/test.yaml
@@ -3,4 +3,10 @@ version: 0.2
 phases:
   build:
     commands:
+      - |
+        for FILE in $(find ./infra -name "*.yaml" -maxdepth 1);do
+          if ! aws cloudformation validate-template --template-body "file://$FILE";then
+            exit 1
+          fi
+        done
       - npm test

--- a/infra/codebuild.yaml
+++ b/infra/codebuild.yaml
@@ -35,6 +35,10 @@ Resources:
                   - logs:PutLogEvents
                 Resource:
                   !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*"
+              - Effect: Allow
+                Action:
+                  - cloudformation:ValidateTemplate
+                Resource: "*"
 
   Codebuild:
     Type: AWS::CodeBuild::Project
@@ -50,7 +54,7 @@ Resources:
         EnvironmentVariables:
           - Name: DESTINATION_BUCKET
             Type: PLAINTEXT
-            # Currently unable to reference this dynamically, see:
+            # Currently unable to reference this dynamically, see:
             # https://stackoverflow.com/a/41727240/4699289
             Value: samhstn.com
       ServiceRole: !Ref BuildRole
@@ -77,7 +81,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        # See all options here:
+        # See all options here:
         # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
         Image: aws/codebuild/nodejs:10.14.1
       ServiceRole: !Ref BuildRole
@@ -98,7 +102,7 @@ Resources:
         EnvironmentVariables:
           - Name: DESTINATION_BUCKET
             Type: PLAINTEXT
-            # Currently unable to reference this dynamically, see:
+            # Currently unable to reference this dynamically, see:
             # https://stackoverflow.com/a/41727240/4699289
             Value: samhstn.com
       ServiceRole: !Ref BuildRole


### PR DESCRIPTION
Fixes #39 

- [x] Fix non-breaking space char in `infra/codebuild.yaml` causing the `--valid-template` command to break.
- [x] Update `BuildRole` policy to allow `ValidTemplate` command to be run.
- [x] Add `--valid-template` check to `infra/buildspecs/test.yaml`