### PR TITLE
Use releases for setting environment variable

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,1 +1,7 @@
 import Config
+
+config :samhstn,
+  port: System.fetch_env!("SAMHSTN_PORT"),
+  host: System.fetch_env!("SAMHSTN_HOST"),
+  secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+  assets_bucket: System.fetch_env!("SAMHSTN_ASSETS_BUCKET")

--- a/lib/samhstn/routes/client.ex
+++ b/lib/samhstn/routes/client.ex
@@ -7,8 +7,8 @@ defmodule Samhstn.Routes.Client do
 
   @spec init() :: [RouteRef.t()]
   def init() do
-    "SAMHSTN_ASSETS_BUCKET"
-    |> System.fetch_env!()
+    :samhstn
+    |> Application.fetch_env!(:assets_bucket)
     |> ExAws.S3.download_file("routes.json", :memory)
     |> ExAws.stream!()
     |> Enum.join()

--- a/lib/samhstn_web/endpoint.ex
+++ b/lib/samhstn_web/endpoint.ex
@@ -26,9 +26,9 @@ defmodule SamhstnWeb.Endpoint do
 
   def init(_key, config) do
     if config[:load_from_system_env] do
-      port = System.fetch_env!("SAMHSTN_PORT")
-      host = System.fetch_env!("SAMHSTN_HOST")
-      secret_key_base = System.fetch_env!("SECRET_KEY_BASE")
+      port = Application.fetch_env!(:samhstn, :port)
+      host = Application.fetch_env!(:samhstn, :host)
+      secret_key_base = Application.fetch_env!(:samhstn, :secret_key_base)
 
       url = [
         scheme: "https",


### PR DESCRIPTION
Fixes #110

We now only read the environment variables once, when the release is booted (see the [`mix release`](https://hexdocs.pm/mix/1.9.0/Mix.Tasks.Release.html#module-runtime-configuration) task for more info).